### PR TITLE
Fixed typo: T replaced S in non-local flux variable

### DIFF
--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -752,7 +752,7 @@ contains
       if (.not.lstable) then
         call cvmix_kpp_compute_nonlocal(Tshape2, sigma(kw), Tnonlocal(kw),    &
                                         CVmix_kpp_params_user)
-        call cvmix_kpp_compute_nonlocal(Sshape2, sigma(kw), Tnonlocal(kw),    &
+        call cvmix_kpp_compute_nonlocal(Sshape2, sigma(kw), Snonlocal(kw),    &
                                         CVmix_kpp_params_user)
       end if
     end do


### PR DESCRIPTION
- Typo was introduced in 2bb51feccae321f65f441a6a848812edc3519b05.
- The typo caused answer changes in all the MOM6 regresion tests
  that use KPP.
