### PR TITLE
Prevent contribution of OBL to interior diffusivity when lenhanced_di…

### DIFF
--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -949,9 +949,36 @@ contains
                                             CVmix_kpp_params_user)
     do kw=2,ktup+1
       !   (3b) Evaluate G(sigma) at each cell interface
-      MshapeAtS = cvmix_math_evaluate_cubic(Mshape, sigma(kw))
-      TshapeAtS = cvmix_math_evaluate_cubic(Tshape, sigma(kw))
-      SshapeAtS = cvmix_math_evaluate_cubic(Sshape, sigma(kw))
+       !BGR{
+       !    KPP boundary layer scheme should not contribute diffusion
+       !      at interfaces below the surface boundary layer.  
+       !      To prevent this, the shape functions are set 
+       !      to 0 if sigma(kw) exceeds 1.  Without this, strange values
+       !      of viscosity can occur immediately below the OBL depth due
+       !      to shape function evaluation at sigma>1.  Note that the 
+       !      contribution of lenhanced_diff to diffusion at the interface
+       !      below the OBL depth is performed separately below.)
+       !---------
+       ! New Code
+       !//////
+       if (sigma(kw).lt. cvmix_one) then
+          MshapeAtS = cvmix_math_evaluate_cubic(Mshape, sigma(kw))
+          TshapeAtS = cvmix_math_evaluate_cubic(Tshape, sigma(kw))
+          SshapeAtS = cvmix_math_evaluate_cubic(Sshape, sigma(kw))
+       else
+          MshapeAtS = 0.0
+          TshapeAtS = 0.0
+          SshapeAtS = 0.0
+       endif
+       !\\\\\\
+       !---------
+       ! Old code
+       !////// 
+       !MshapeAtS = cvmix_math_evaluate_cubic(Mshape, sigma(kw))
+       !TshapeAtS = cvmix_math_evaluate_cubic(Tshape, sigma(kw))
+       !SshapeAtS = cvmix_math_evaluate_cubic(Sshape, sigma(kw))
+       !\\\\\\
+       !}BGR
 
       !   (3c) Compute nonlocal term at each cell interface
       if ((.not.lstable).and.(kw.le.kwup)) then


### PR DESCRIPTION
…ff set to false.

Located a potential bug when "lenhanced_diff" is set to false.  In this case, the diffusivity/viscosity at the interface below the boundary layer should only be due to the interior scheme and the boundary layer contribution should be 0.  However, what appears to be a bug caused the shape function to be evaluated for the first interface in which sigma>1, which caused the OBL scheme to contribute to diffusivity/viscosity at this first interior interface.  This gave strange results causing the boundary layer to "jump" periodically as these artificial diffusivities mixed interior layers into the boundary layer.  If "enhanced_diff" is enabled, this value would be correctly replaced before the diffusivity is output, but if it is disabled, this value makes it into the output diffusivity profile. 

See my proposed fix, where I set the shape function equal to 0 when sigma exceeds or equals 1.  The proposed fix zeros out the shape function for case sigma>=1, preventing this artificial diffusivity.