### PR TITLE
A different approach to fixing enhanced diffusivity bug

### DIFF
--- a/src/drivers/cvmix_kpp_drv.F90
+++ b/src/drivers/cvmix_kpp_drv.F90
@@ -329,7 +329,6 @@ Subroutine cvmix_kpp_driver()
 
       call cvmix_init_kpp(ri_crit=ri_crit, vonkarman=0.4_cvmix_r8,            &
                           interp_type2=interp_type_t4, lnoDGat1=lnoDGat1,     &
-                          MatchTechnique='MatchGradient',                     &
                           lenhanced_diff=(i.eq.1))
       call cvmix_coeffs_kpp(CVmix_vars4)
 
@@ -378,7 +377,6 @@ Subroutine cvmix_kpp_driver()
 
       call cvmix_init_kpp(ri_crit=ri_crit, vonkarman=0.4_cvmix_r8,            &
                           interp_type2=interp_type_t4, lnoDGat1=lnoDGat1,     &
-                          MatchTechnique='MatchGradient',                     &
                           lenhanced_diff=(i.eq.1))
       call cvmix_coeffs_kpp(CVmix_vars4)
 

--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -952,14 +952,14 @@ contains
                                             surf_fric, langmuir_Efactor,      &
                                             w_m, w_s,                         &
                                             CVmix_kpp_params_user)
-    do kw=2,ktup+1
+    do kw=2,kwup
       !   (3b) Evaluate G(sigma) at each cell interface
       MshapeAtS = cvmix_math_evaluate_cubic(Mshape, sigma(kw))
       TshapeAtS = cvmix_math_evaluate_cubic(Tshape, sigma(kw))
       SshapeAtS = cvmix_math_evaluate_cubic(Sshape, sigma(kw))
 
       !   (3c) Compute nonlocal term at each cell interface
-      if ((.not.lstable).and.(kw.le.kwup)) then
+      if (.not.lstable) then
         GAtS = cvmix_math_evaluate_cubic(Tshape2, sigma(kw))
         Tnonlocal(kw) = CVmix_kpp_params_in%nonlocal_coeff*GAtS
         GAtS = cvmix_math_evaluate_cubic(Sshape2, sigma(kw))


### PR DESCRIPTION
This pull request is a different approach to #64 - we should merge one or the other but don't need both. @breichl and @vanroekel can you let me know if this fix is okay? Besides the small update to fix the bug in `cvmix_kpp.F90`, I also updated the KPP driver -- there was a test that computed diffusivities in a column when the boundary layer was between the top interface and the cell center as well as between the cell center and bottom interface, but both were computed with enhanced diffusivity. There are now four subtests, the two original ones and the same two tests but with enhanced diffusivity off. I have verified that this fix does not change answers when `lenhanced_diff=.true.` and the difference between `lenhanced_diff=.true.` and `lenhanced_diff=.false.` is as expected: a change in the deepest non-zero diffusivity while the rest of the diffusivities are unchanged.