### PR TITLE
Fixes a bug in evaluate cubic

### DIFF
--- a/src/shared/cvmix_math.F90
+++ b/src/shared/cvmix_math.F90
@@ -244,7 +244,7 @@
       cvmix_math_evaluate_cubic = cvmix_math_evaluate_cubic +                 &
                                   coeffs(i)*(x_in**(i-1))
       if (present(fprime).and.(i.gt.2)) &
-        fprime = fprime + real(i-1,cvmix_r8)*(x_in**(i-2))
+        fprime = fprime + coeffs(i)*real(i-1,cvmix_r8)*(x_in**(i-2))
     end do
 
   end function cvmix_math_evaluate_cubic


### PR DESCRIPTION
In current CVMix master, the returned value of fprime in evaluate cubic
is not correct.  For example, when linear interpolation is used, the
returned value of fprime is

fprime = coeffs(2) + h + h^2

it should be

fprime = coeffs(2) + coeffs(3)*h + coeffs(4)*h^2

As it currently sits, the returned fprime is much too large (6 orders of
magnitude in my tests relative to the corrected version)