### PR TITLE
Performance enhancement

### DIFF
--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -1375,8 +1375,7 @@ contains
       lstable = (surf_buoy.gt.cvmix_zero)
 
       if (lstable) then
-        MoninObukhov = surf_fric**3/(surf_buoy*cvmix_get_kpp_real('vonkarman',&
-                                                     CVmix_kpp_params_in))
+        MoninObukhov = surf_fric**3/(surf_buoy*CVmix_kpp_params_in%vonkarman)
       else
         MoninObukhov = abs(zt_cntr(nlev))
       end if
@@ -1985,7 +1984,7 @@ contains
           do kw=1,n_sigma
             ! Compute (u*/phi_m)^3 [this is where the zeros in numerator and
             !                       denominator cancel when u* = 0]
-            w_m(kw) = -cvmix_get_kpp_real('c_m', CVmix_kpp_params_in) *       &
+            w_m(kw) = -CVmix_kpp_params_in%c_m *                              &
                       min(surf_layer_ext, sigma_coord(kw)) * OBL_depth *      &
                       vonkar * surf_buoy_force
             ! w_m = vonkar * u* / phi_m
@@ -2004,7 +2003,7 @@ contains
           do kw=1,n_sigma
             ! Compute (u*/phi_s)^3 [this is where the zeros in numerator and
             !                       denominator cancel when u* = 0]
-            w_s(kw) = -cvmix_get_kpp_real('c_s', CVmix_kpp_params_in) *       &
+            w_s(kw) = -CVmix_kpp_params_in%c_s *                              &
                       min(surf_layer_ext, sigma_coord(kw)) * OBL_depth *      &
                       vonkar * surf_buoy_force
             ! w_s = vonkar * u* / phi_s
@@ -2155,7 +2154,7 @@ contains
           else
             ! Compute (u*/phi_m)^3 [this is where the zeros in numerator and
             !                       denominator cancel when u* = 0]
-            w_m(kw) = -cvmix_get_kpp_real('c_m', CVmix_kpp_params_in) *       &
+            w_m(kw) = -CVmix_kpp_params_in%c_m *                              &
                       min(surf_layer_ext, sigma_coord) * OBL_depth(kw) *      &
                       vonkar * surf_buoy_force(kw)
             ! w_m = vonkar * u* / phi_m
@@ -2175,7 +2174,7 @@ contains
             ! Unstable forcing, Eqs. (13) and (B1e) reduce to following
             ! Compute (u*/phi_s)^3 [this is where the zeros in numerator and
             !                       denominator cancel when u* = 0]
-            w_s(kw) = -cvmix_get_kpp_real('c_s', CVmix_kpp_params_in) *       &
+            w_s(kw) = -CVmix_kpp_params_in%c_s *                              &
                       min(surf_layer_ext, sigma_coord) * OBL_depth(kw) *      &
                       vonkar * surf_buoy_force(kw)
             ! w_s = vonkar * u* / phi_s
@@ -2343,11 +2342,11 @@ contains
       if (zeta.ge.cvmix_zero) then
         ! Stable region
         compute_phi_inv = cvmix_one/(cvmix_one + real(5,cvmix_r8)*zeta)
-      else if (zeta.ge.cvmix_get_kpp_real('zeta_m', CVmix_kpp_params_in)) then
+      else if (zeta.ge.CVmix_kpp_params_in%zeta_m) then
         compute_phi_inv = (cvmix_one - real(16,cvmix_r8)*zeta)**0.25_cvmix_r8
       else
-        compute_phi_inv = (cvmix_get_kpp_real('a_m', CVmix_kpp_params_in) -      &
-                          cvmix_get_kpp_real('c_m', CVmix_kpp_params_in)*zeta)** &
+        compute_phi_inv = (CVmix_kpp_params_in%a_m -                          &
+                          CVmix_kpp_params_in%c_m*zeta)**                     &
                           (cvmix_one/real(3,cvmix_r8))
       end if
     end if
@@ -2356,11 +2355,11 @@ contains
       if (zeta.ge.cvmix_zero) then
         ! Stable region
         compute_phi_inv = cvmix_one/(cvmix_one + real(5,cvmix_r8)*zeta)
-      else if (zeta.ge.cvmix_get_kpp_real('zeta_s', CVmix_kpp_params_in)) then
+      else if (zeta.ge.CVmix_kpp_params_in%zeta_s) then
         compute_phi_inv = (cvmix_one - real(16,cvmix_r8)*zeta)**0.5_cvmix_r8
       else
-        compute_phi_inv = (cvmix_get_kpp_real('a_s', CVmix_kpp_params_in) -      &
-                          cvmix_get_kpp_real('c_s', CVmix_kpp_params_in)*zeta)** &
+        compute_phi_inv = (CVmix_kpp_params_in%a_s -                          &
+                          CVmix_kpp_params_in%c_s*zeta)**                     &
                           (cvmix_one/real(3,cvmix_r8))
       end if
     end if

--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -2280,12 +2280,12 @@ contains
     end if
 
     ! From LMD 94, Vtc = sqrt(-beta_T/(c_s*eps))/kappa^2
-    Vtc = sqrt(0.2_cvmix_r8/(cvmix_get_kpp_real('c_s', CVmix_kpp_params_in) * &
-                cvmix_get_kpp_real('surf_layer_ext', CVmix_kpp_params_in))) / &
-          (cvmix_get_kpp_real('vonkarman', CVmix_kpp_params_in)**2)
+    Vtc = sqrt(0.2_cvmix_r8/(CVmix_kpp_params_in%c_s * &
+                CVmix_kpp_params_in%surf_layer_ext)) / &
+          (CVmix_kpp_params_in%vonkarman**2)
     do kt=1,nlev
       if (CVmix_kpp_params_in%lscalar_Cv) then
-        Cv = cvmix_get_kpp_real('Cv', CVmix_kpp_params_in)
+        Cv = CVmix_kpp_params_in%Cv
       else
         ! Cv computation comes from Danabasoglu et al., 2006
         if (N_cntr(kt).lt.0.002_cvmix_r8) then


### PR DESCRIPTION
Taking a crack at speeding up CVMix inside POP without changing answers. Initial analysis showed that using CVMix instead of POP's original KPP implementation increased total model cost of a G compset by ~16%, broken down roughly as follows (some additional costs have not been accounted for but thanks to rounding it doesn't look that way):

11%: computing the boundary layer depth (9.5% computing unresolved shear, 1.5% interpolation to determine boundary layer depth)
2.5%: transposing data (copying into / out of the CVMix data structure) / other CVMix-specific actions
2.5%: computing the mixing coefficients inside the boundary layer

The first commit in this PR addresses some of the slowdown in `compute_unresolved_shear()`. It still needs to be tested more thoroughly, and I'd like to leave this open a little longer to have a crack at some other performance improvements, but opening the PR so that it doesn't get lost ahead of the CESM 2.1 release.