### PR TITLE
Fix a couple of bugs

### DIFF
--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -1425,7 +1425,7 @@ contains
     ! Error checks
     ! (1) if using Ekman length, need to pass surf_fric and Coriolis
     if ((.not.(present(surf_fric).and.present(Coriolis))).and.                &
-        CVmix_kpp_params_in%lMonOb) then
+        CVmix_kpp_params_in%lEkman) then
       print*, "ERROR: must pass surf_fric and Coriolis if you want to ",      &
                 "compute Ekman length"
       stop 1

--- a/src/shared/cvmix_shear.F90
+++ b/src/shared/cvmix_shear.F90
@@ -384,7 +384,7 @@ contains
         PP_alpha   = CVmix_shear_params%PP_alpha
         loc_exp    = CVmix_shear_params%PP_exp
         PP_nu_b    = CVmix_shear_params%PP_nu_b
-        PP_kappa_b = CVmix_shear_params%PP_nu_b
+        PP_kappa_b = CVmix_shear_params%PP_kappa_b
 
         ! Pacanowski-Philander
         do kw=1,nlev+1


### PR DESCRIPTION
Fixes #81 
Fixes #82 

As @OGutjahr there were a couple of bugs that basically came down to using the wrong variable name. For the issue in `cvmix_shear.F90`, our test suite wasn't testing that particular use case so we don't see any changes. For the issue in `cvmix_kpp.F90`, the error condition we were trying to capture will be reported correctly instead of resulting in a "variable not present" type error.