### PR TITLE
Specify older Ubuntu distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
+dist: trusty
 language: python
 sudo: required
-before_install:
-  - sudo apt-get install gfortran mpich libnetcdf-dev netcdf-bin
+
+addons:
+   apt:
+      packages:
+         - netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
+
 python:
   - '2.7'
   - '3.6'
+
 script:
   - cd bld; ./cvmix_setup gfortran $(dirname $(dirname $(which nc-config)))
   - cd ../CVMix_tools; ./run_test_suite.sh --already-ran-setup
+
 branches:
   only:
   - master


### PR DESCRIPTION
The best way I've found to ensure compatibility between `gfortran` and `netcdf` in
automated testing is to use `trusty` (which is no longer the default
distribution). I've also slightly refactored the way `apt` packages are
requested, and switched from `mpich` to `openmpi`.