### PR TITLE
Update stokes most

### DIFF
--- a/src/drivers/cvmix_kpp_drv.F90
+++ b/src/drivers/cvmix_kpp_drv.F90
@@ -697,7 +697,7 @@ Subroutine cvmix_kpp_driver()
     call cvmix_kpp_compute_StokesXi(zi=zt,                                    &
                                     zk=zw_iface,                              &
                                     kSL=(nlev7+1)/2,                          &
-                                    SLDepth=cvmix_zero,                       &
+                                    SLDepth=cvmix_one,                        &
                                     surf_buoy_force=cvmix_one,                &
                                     surfBuoy_NS=cvmix_one,                    &
                                     surf_fric_vel=cvmix_one,                  &

--- a/src/drivers/cvmix_kpp_drv.F90
+++ b/src/drivers/cvmix_kpp_drv.F90
@@ -62,7 +62,7 @@ Subroutine cvmix_kpp_driver()
   real(cvmix_r8) :: hmix1, hmix5, hmix7,  ri_crit, layer_thick1,              &
                     layer_thick4, layer_thick5, layer_thick7, OBL_depth4,     &
                     OBL_depth5, OBL_depth7, N, Nsqr
-  real(cvmix_r8) :: StokesXI
+  real(cvmix_r8) :: StokesXI, BEdE_ER, PU_TKE, PS_TKE, PB_TKE
   real(cvmix_r8) :: kOBL_depth, Bslope, Vslope
   real(cvmix_r8) :: sigma6, OBL_depth6, surf_buoy_force6, surf_fric_vel6,     &
                     vonkarman6, tao, rho0, grav, alpha, Qnonpen, Cp0,         &
@@ -690,11 +690,16 @@ Subroutine cvmix_kpp_driver()
              vSbar(nlev7), &
              source=cvmix_one)
     StokesXI = cvmix_one
+    BEdE_ER  = cvmix_one
+    PU_TKE  = cvmix_one
+    PS_TKE  = cvmix_one
+    PB_TKE  = cvmix_one
     call cvmix_kpp_compute_StokesXi(zi=zt,                                    &
                                     zk=zw_iface,                              &
                                     kSL=(nlev7+1)/2,                          &
                                     SLDepth=cvmix_zero,                       &
                                     surf_buoy_force=cvmix_one,                &
+                                    surfBuoy_NS=cvmix_one,                    &
                                     surf_fric_vel=cvmix_one,                  &
                                     omega_w2x=cvmix_one,                      &
                                     uE=ones,                                  &
@@ -703,11 +708,15 @@ Subroutine cvmix_kpp_driver()
                                     vS=vS,                                    &
                                     uSbar=uSbar,                              &
                                     vSbar=vSbar,                              &
-                                    uS_SL=cvmix_one,                         &
-                                    vS_SL=cvmix_one,                         &
-                                    uSb_SL=cvmix_one,                      &
-                                    vSb_SL=cvmix_one,                      &
-                                    StokesXI=StokesXI)
+                                    uS_SL=cvmix_one,                          &
+                                    vS_SL=cvmix_one,                          &
+                                    uSb_SL=cvmix_one,                         &
+                                    vSb_SL=cvmix_one,                         &
+                                    StokesXI=StokesXI,                        &
+                                    BEdE_ER=BEdE_ER,                          &
+                                    PU_TKE=PU_TKE,                            &
+                                    PS_TKE=PS_TKE,                            &
+                                    PB_TKE=PB_TKE)
     call cvmix_kpp_compute_OBL_depth(Ri_bulk, zw_iface, OBL_depth7,           &
                                      kOBL_depth, zt, surf_fric=cvmix_one,     &
                                      surf_buoy=ones, Xi=ones)

--- a/src/drivers/cvmix_kpp_drv.F90
+++ b/src/drivers/cvmix_kpp_drv.F90
@@ -703,10 +703,10 @@ Subroutine cvmix_kpp_driver()
                                     vS=vS,                                    &
                                     uSbar=uSbar,                              &
                                     vSbar=vSbar,                              &
-                                    uS_SLD=cvmix_one,                         &
-                                    vS_SLD=cvmix_one,                         &
-                                    uSbar_SLD=cvmix_one,                      &
-                                    vSbar_SLD=cvmix_one,                      &
+                                    uS_SL=cvmix_one,                         &
+                                    vS_SL=cvmix_one,                         &
+                                    uSbar_SL=cvmix_one,                      &
+                                    vSbar_SL=cvmix_one,                      &
                                     StokesXI=StokesXI)
     call cvmix_kpp_compute_OBL_depth(Ri_bulk, zw_iface, OBL_depth7,           &
                                      kOBL_depth, zt, surf_fric=cvmix_one,     &

--- a/src/drivers/cvmix_kpp_drv.F90
+++ b/src/drivers/cvmix_kpp_drv.F90
@@ -705,8 +705,8 @@ Subroutine cvmix_kpp_driver()
                                     vSbar=vSbar,                              &
                                     uS_SL=cvmix_one,                         &
                                     vS_SL=cvmix_one,                         &
-                                    uSbar_SL=cvmix_one,                      &
-                                    vSbar_SL=cvmix_one,                      &
+                                    uSb_SL=cvmix_one,                      &
+                                    vSb_SL=cvmix_one,                      &
                                     StokesXI=StokesXI)
     call cvmix_kpp_compute_OBL_depth(Ri_bulk, zw_iface, OBL_depth7,           &
                                      kOBL_depth, zt, surf_fric=cvmix_one,     &

--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -3434,7 +3434,7 @@ contains
     taux0   = ustar**2 * cos(omega_w2x)
     tauy0   = ustar**2 * sin(omega_w2x)
     Stk0    = sqrt( uS(1)**2 + vS(1)**2 )
-    BLDepth = SLDepth / CVmix_kpp_params_in%surf_layer_ext
+    BLdepth = SLDepth / CVmix_kpp_params_in%surf_layer_ext
 
     ! Parameterized Buoyancy production of TKE
     PBfact = 0.0893759_cvmix_r8

--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -3532,7 +3532,7 @@ contains
 ! until the boundary layer depth, ERdepth > 0 kER_depth are determined, OR
 ! if there is no viable solution  ERdepth = -1 , kER_depth=-1
 
-  subroutine cvmix_kpp_compute_ER_depth( z_inter,Nsq,deltaRho,OBL_depth, &
+  subroutine cvmix_kpp_compute_ER_depth( z_inter,Nsq,OBL_depth, &
            uStar,Bsfc_ns,surfBuoy,StokesXI,BEdE_ER,ERdepth,  &
            CVMix_kpp_params_user)
 
@@ -3542,7 +3542,6 @@ contains
                  Nsq                            ! Column of Buoyancy Gradients at interfaces
   real(cvmix_r8), dimension(:), intent(in) :: &
                  OBL_depth,                   & ! Array of assumed OBL depths >0 at cell centers [m]
-                 deltaRho,                    & ! Column of Local density difference from surface at centers [kg m-3]
                  surfBuoy,                    & ! surface Buoyancy flux surface to OBL_depth
                  StokesXI,                    & ! Stokes similarity parameter given OBL_depth
                  BEdE_ER                        ! Parameterized Entrainment Rule given OBL_depth

--- a/src/shared/cvmix_kpp.F90
+++ b/src/shared/cvmix_kpp.F90
@@ -3609,7 +3609,7 @@ contains
 
       ! find the peak
       if ( (Bflux(iz+1) .gt. Bflux(iz+2)) .and. (Bflux(iz+1) .ge. Bflux(iz)) .and. &
-           (Bflux(iz+1).gt. cvmix_zero) ) then
+           (Bflux(iz+1) .gt. cvmix_zero) ) then
         ! Find sigE (the root of the derivative of the quadratic polynomial
         ! interpolating (sigma(i), Bflux(i)) for i in [iz, iz+1, iz+2])
         ! Also find BEnt (value of quadratic at sigE)


### PR DESCRIPTION
* Add new subroutine `cvmix_kpp_compute_ER_depth` to calculate the entrainment flux and corresponding depth using the entrainment rule. For each assumed boundary layer depth (`OBL_depth`) at cell centers, the subroutine iteratively searches for the first depth where the entrainment depth (`ERdepth`) becomes positive. The corresponding index (`kER_depth`) is also returned. If no viable solution is found, the subroutine returns `ERdepth = -1` and `kER_depth = -1`.
* Add new subroutine `cvmix_kpp_quad_fit` to estimate the maximum of a quadratic fit. 
* Update `cvmix_kpp_compute_StokesXi`
* Compute Shear, Stokes, Buoyancy, surface-layer TKE Production